### PR TITLE
ERC1155 Support

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -300,6 +300,18 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         handler.withdraw(tokenAddress, recipient, amountOrTokenID);
     }
 
+    function adminWithdraw(
+        address handlerAddress,
+        address tokenAddress,
+        address recipient,
+        uint256 tokenId,
+        uint256 amount,
+        bytes memory extraData
+    ) external onlyAdmin {
+        IERCHandler handler = IERCHandler(handlerAddress);
+        handler.withdraw(tokenAddress, recipient, tokenId, amount, extraData);
+    }
+
     /**
         @notice Initiates a transfer using a specified handler contract.
         @notice Only callable when Bridge is not paused.

--- a/contracts/ERC1155MinterBurnerPauser.sol
+++ b/contracts/ERC1155MinterBurnerPauser.sol
@@ -1,0 +1,10 @@
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts/presets/ERC1155PresetMinterPauser.sol";
+
+contract ERC1155MinterBurnerPauser is ERC1155PresetMinterPauser {
+  constructor(string memory uri) ERC1155PresetMinterPauser(uri) public {
+    // Do nothing. This exists to make the ERC1155PresetMinterPauser contract available to 
+    // consuming interfaces (e.g., the relayer)
+  }
+}

--- a/contracts/ERC1155Safe.sol
+++ b/contracts/ERC1155Safe.sol
@@ -1,0 +1,81 @@
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "./ERC1155MinterBurnerPauser.sol";
+
+/**
+    @title Manages deposited ERC1155s.
+    @author ChainSafe Systems.
+    @notice This contract is intended to be used with ERC1155Handler contract.
+ */
+contract ERC1155Safe {
+    using SafeMath for uint256;
+
+    /**
+        @notice Used to transfer tokens into the safe to fund proposals.
+        @param tokenAddress Address of ERC1155 contract address.
+        @param owner Address of current token owner.
+        @param tokenID ID of token to transfer.
+        @param amount The amount of a specific tokenID to send
+        @param extraData The required data param on transfers (not used by all 1155's)
+     */
+    function fundERC1155(address tokenAddress, address owner, uint tokenID, uint amount, bytes memory extraData) public {
+        IERC1155 erc1155 = IERC1155(tokenAddress);
+        erc1155.safeTransferFrom(owner, address(this), tokenID, amount, extraData);
+    }
+
+    /**
+        @notice Used to gain custoday of deposited token.
+        @param tokenAddress Address of ERC1155 contract address.
+        @param owner Address of current token owner.
+        @param recipient Address to transfer token to.
+        @param tokenID ID of token to transfer.
+        @param amount The amount of a specific tokenID to send
+        @param extraData The required data param on transfers (not used by all 1155's)
+
+     */
+    function lockERC1155(address tokenAddress, address owner, address recipient, uint tokenID, uint amount, bytes memory extraData) internal {
+        IERC1155 erc1155 = IERC1155(tokenAddress);
+        erc1155.safeTransferFrom(owner, recipient, tokenID, amount, extraData);
+    }
+
+    /**
+        @notice Transfers custody of token to recipient.
+        @param tokenAddress Address of ERC1155 contract address.
+        @param owner Address of current token owner.
+        @param recipient Address to transfer token to.
+        @param tokenID ID of token to transfer.
+        @param amount The amount of a specific tokenID to send
+        @param extraData The required data param on transfers (not used by all 1155's)
+     */
+    function releaseERC1155(address tokenAddress, address owner, address recipient, uint256 tokenID, uint amount, bytes memory extraData) internal {
+        IERC1155 erc1155 = IERC1155(tokenAddress);
+        erc1155.safeTransferFrom(owner, recipient, tokenID, amount, extraData);
+    }
+
+    /**
+        @notice Used to create new ERC1155s.
+        @param tokenAddress Address of ERC1155 to mint.
+        @param recipient Address to mint token to.
+        @param tokenID ID of token to mint.
+        @param extraData Optional data to send along with mint call.
+     */
+    function mintERC1155(address tokenAddress, address recipient, uint256 tokenID, uint amount, bytes memory extraData) internal {
+        ERC1155MinterBurnerPauser erc1155 = ERC1155MinterBurnerPauser(tokenAddress);
+        erc1155.mint(recipient, tokenID, amount, extraData);
+    }
+
+    /**
+        @notice Used to burn ERC1155s.
+        @param tokenAddress Address of ERC1155 to burn.
+        @param owner Address of account that owns the tokens being burnt.
+        @param tokenID ID of token to burn.
+        @param amount of tokenID to burn.
+     */
+    function burnERC1155(address tokenAddress, address owner, uint256 tokenID, uint amount) internal {
+        ERC1155MinterBurnerPauser erc1155 = ERC1155MinterBurnerPauser(tokenAddress);
+        erc1155.burn(owner, tokenID, amount);
+    }
+
+}

--- a/contracts/handlers/ERC20Handler.sol
+++ b/contracts/handlers/ERC20Handler.sol
@@ -160,4 +160,9 @@ contract ERC20Handler is IDepositExecute, HandlerHelpers, ERC20Safe {
     function withdraw(address tokenAddress, address recipient, uint amount) external override onlyBridge {
         releaseERC20(tokenAddress, recipient, amount);
     }
+
+    // Support new withdraw signature: tokenID and extraData are ignored.
+    function withdraw(address tokenAddress, address recipient, uint tokenID, uint256 amount, bytes memory extraData) external override onlyBridge {
+        this.withdraw(tokenAddress, recipient, amount);
+    }
 }

--- a/contracts/handlers/HandlerHelpers.sol
+++ b/contracts/handlers/HandlerHelpers.sol
@@ -55,12 +55,22 @@ contract HandlerHelpers is IERCHandler {
     }
 
     /**
-        @notice Used to manually release funds from ERC safes.
+        @notice Used to manually release funds from ERC safes. This signature is not supported by ERC1155 handlers.
         @param tokenAddress Address of token contract to release.
         @param recipient Address to release tokens to.
         @param amountOrTokenID Either the amount of ERC20 tokens or the ERC721 token ID to release.
      */
     function withdraw(address tokenAddress, address recipient, uint256 amountOrTokenID) external virtual override {}
+    
+     /**
+        @notice Used to manually release funds from ERC safes (updated signature to support ERC 1155)
+        @param tokenAddress Address of token contract to release.
+        @param recipient Address to release tokens to.
+        @param tokenID ERC721 or ERC1155 token ID to release.
+        @param amount ERC20 or ERC1155 amount of token to release.
+        @param extraData The optional data parameter for ERC1155.
+     */
+    function withdraw(address tokenAddress, address recipient, uint256 tokenID, uint256 amount, bytes memory extraData) external virtual override {}
 
     function _setResource(bytes32 resourceID, address contractAddress) internal {
         _resourceIDToTokenContractAddress[resourceID] = contractAddress;

--- a/contracts/interfaces/IERCHandler.sol
+++ b/contracts/interfaces/IERCHandler.sol
@@ -17,10 +17,19 @@ interface IERCHandler {
      */
     function setBurnable(address contractAddress) external;
     /**
-        @notice Used to manually release funds from ERC safes.
+        @notice Used to manually release funds from ERC safes. This signature is not supported by ERC1155 handlers.
         @param tokenAddress Address of token contract to release.
         @param recipient Address to release tokens to.
         @param amountOrTokenID Either the amount of ERC20 tokens or the ERC721 token ID to release.
      */
     function withdraw(address tokenAddress, address recipient, uint256 amountOrTokenID) external;
+    /**
+        @notice Used to manually release funds from ERC safes (updated signature to support ERC 1155)
+        @param tokenAddress Address of token contract to release.
+        @param recipient Address to release tokens to.
+        @param tokenID ERC721 or ERC1155 token ID to release.
+        @param amount ERC20 or ERC1155 amount of token to release.
+        @param extraData The optional data parameter for ERC1155.
+     */
+    function withdraw(address tokenAddress, address recipient, uint256 tokenID, uint256 amount, bytes memory extraData) external;
 }


### PR DESCRIPTION
Creates an `ERC1155Handler`, `ERC1155Safe`, and an `ERC1155MinterBurnerParser` contract to support ERC1155 tokens. Some details:

- the `withdraw()` function supported by handlers doesn't have the correct signature to support 1155 transfers, so I a new signature that supports all three (20, 721 and 1155) while maintaining backward compatibility with the old `withdraw()` function.
- I organized the data sent through proposals on 1155's slightly different than that of 721s, for easier parsing. I packed the `uint256` data to the front of the payload, then left the variable length data for the end.
- ERC1155 requires an unformatted set of bytes (called `data` within the EIP, and `extraData` within this PR) be passed with all token transfers. Normal usage is to send an empty string as not all token contracts use it. This data could be needed by the token contracts, so we make sure to pass it over the bridge. 
- Unlike 721's, there's no need to check for specific URIs or the metadata extension and send that data over the bridge, as EIP1155's metadata uris support variable injection and thus support all token types. This means the correct metadata URL needs to be set on token contract creation (on both sides of the bridge) rather than passed over directly. 
